### PR TITLE
Seed the database automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ docker volume create hitobito_bundle
 docker volume create hitobito_yarn_cache
 ```
 
-⚡ If your user id is not 1000 (run id -u to check), you need to export this as env variable: **export UID=$UID** before running any of the further commands. Maybe you want to add this to your bashrc. 
-
-⚡ This will also install all required gems which takes some time to complete if it's executed the first time.
+⚡ If your user id is not 1000 (run id -u to check), you need to export this as env variable: **export UID=$UID** before running any of the further commands. Maybe you want to add this to your bashrc.
 
 ## Start Development Containers
 
@@ -77,7 +75,9 @@ To start the Hitobito application, run the following command in your shell:
 docker-compose up -d
 ```
 
-After this command completed, make sure all services are up and running:
+⚡ This will also install all required gems and seed the database, which takes some time to complete if it's executed the first time. You can follow the progress using `docker-compose logs --follow rails` (exit with Ctrl+C).
+
+After the startup has completed (once you see `Listening on tcp://0.0.0.0:3000` in the logs), make sure all services are up and running:
 
 ```bash
 docker-compose ps
@@ -96,7 +96,7 @@ development_sphinx_1        sphinx-start                     Up      36307/tcp
 development_worker_1        rails-entrypoint rails job ...   Up      8080/tcp
 ```
 
-Access webapplication by browser: http://localhost:3000 and log in using *hitobito@puzzle.ch* and password *hito42bito*. For some wagons, the e-mail address is different. Go to the file ```/config/settings.yml``` inside your wagon repository and look out for the field "root_email". Use this e-mail address to login.
+Access the web application by browser: http://localhost:3000 and log in using *hitobito@puzzle.ch* and password *hito42bito*. For some wagons, the e-mail address is different. Go to the file ```/config/settings.yml``` inside your wagon repository and look out for the field "root_email". Use this e-mail address to login.
 
 ## E-Mails
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ drwxrwxr-x 18 ps ps 4.0K Jun 25 07:29 hitobito
 drwxrwxr-x 11 ps ps 4.0K Jun 24 10:53 hitobito_generic
 ```
 
-## Install Gems / Setup Database
+## Prepare storage space for dependencies
 
 If you did not so before, create new docker volumes for storing bundled gems and yarn packages:
 
@@ -66,12 +66,6 @@ docker volume create hitobito_yarn_cache
 ```
 
 ⚡ If your user id is not 1000 (run id -u to check), you need to export this as env variable: **export UID=$UID** before running any of the further commands. Maybe you want to add this to your bashrc. 
-
-Now it's time to seed the database with development seeds:
-
-```bash
-docker-compose run rails 'rails db:seed wagon:seed'
-```
 
 ⚡ This will also install all required gems which takes some time to complete if it's executed the first time.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
     - ./app/:/usr/src/app
     - hitobito_bundle:/opt/bundle
+    - seed:/seed
     - ./docker/home/rails:/home/developer
     - /tmp/.X11-unix:/tmp/.X11-unix
 
@@ -91,6 +92,7 @@ services:
 
 volumes:
   db:
+  seed:
   hitobito_bundle:
     external: true
   hitobito_yarn_cache:

--- a/docker/Rails.dockerfile
+++ b/docker/Rails.dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install direnv -y
 RUN apt-get install -y xvfb chromium chromium-driver
 
 RUN mkdir /opt/bundle && chmod 777 /opt/bundle
-
+RUN mkdir /seed && chmod 777 /seed
 RUN mkdir /home/developer && chmod 777 /home/developer
 ENV HOME=/home/developer
 

--- a/docker/rails-entrypoint
+++ b/docker/rails-entrypoint
@@ -25,6 +25,16 @@ if [ -z "$SKIP_RAILS_MIGRATIONS" ]; then
   echo "✅ Migrations done"
 fi
 
+if [ -z "$SKIP_SEEDS" ]; then
+  if [ ! -f /seed/done ]; then
+    echo "⚙️  Seeding DB"
+    bundle exec rails db:seed wagon:seed && date > /seed/done
+    echo "✅ Seeding done"
+  else
+    echo "↪️  Skipping seeding because already done on $(cat /seed/done)"
+  fi
+fi
+
 echo "➡️ Handing control over to '$*''"
 
 echo "⚙️  Executing: $@"


### PR DESCRIPTION
Inspired by https://github.com/nxt-engineering/hitobito-docker/commit/9bd0f0a2e28e506068fbe9edffa6848b1bcebec2

One fewer step to get your hitobito instance up and running! Since the database storage is inside a volume, we can simply also store the "has been seeded" flag in a volume.

People who have used this repo before this PR is merged need to rebuild the containers (`git pull && docker-compose build`).