### PR TITLE
Document how to run feature specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ or, to run specific tests:
 
 ```bash
 rspec spec/models/person_spec.rb
+
+# To run a capybara feature spec, which runs inside a real browser, pass the following flag:
+rspec --tag type:feature spec/features/person/person_tags_spec.rb
 ```
 
 ### HTTP request debugging with pry


### PR DESCRIPTION
I always forget that the exact required parameter is `--tag type:feature` and have to look it up in the source code of the rake task. So I wanted to document it in the README instead.