### PR TITLE
MySQL Bug triggers huge memory allocation with high open file limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,11 @@ services:
     - ./docker/mysql-setup.sql:/docker-entrypoint-initdb.d/mysql-setup.sql:ro
     - ./docker/test-setup.sql:/docker-entrypoint-initdb.d/test-setup.sql:ro
     - db:/var/lib/mysql
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 26677
+        hard: 46677
 
   webpack:
     build:


### PR DESCRIPTION
On some systems (for example ArchLinux) there is by default a large open file limit configured. MySQL 5.7 has a bug that triggers it to allocate a lot of RAM at startup (more than 16 GB!). This bug was fixed in later versions of MySQL. As a workaround the problem can be avoided by adding small ulimits in the docker-compose file which I have done in this commit.

For more information see here: https://bugs.mysql.com/bug.php?id=96525 and https://github.com/docker-library/mysql/issues/579.