### PR TITLE
docker-compose: Expose mailcatcher port locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       context: ./docker
       dockerfile: mailcatcher.dockerfile
     ports:
+    - "1025:1025"
     - "1080:1080"
 
   cache:


### PR DESCRIPTION
That way we can run rails locally while still running mailcatcher in the docker container.