### PR TITLE
Always use hitobito as hit project

### DIFF
--- a/bin/dev-env.sh
+++ b/bin/dev-env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]:-$_}")")"
+SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]:-$_}")")
 
-bash --rcfile $SCRIPT_DIR/hit/_hit
+bash --rcfile "$SCRIPT_DIR/hit/_hit"

--- a/bin/fresh-restart
+++ b/bin/fresh-restart
@@ -1,6 +1,6 @@
-#/usr/bin/env bash
-nameb=$(basename $(pwd))
+#!/usr/bin/env bash
+
 docker compose kill
 docker compose rm -vf
-docker volume rm ${nameb}_postgres ${nameb}_seed ${nameb}_sphinx_indexes
+docker volume rm hitobito_postgres hitobito_seed hitobito_sphinx_indexes
 docker compose up -d

--- a/bin/hit/_hit
+++ b/bin/hit/_hit
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
 
 HIT_SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]:-$_}")")"
-HIT_PROJECT="$(basename "$(cd "$HIT_SCRIPT_DIR/../../" && pwd)")"
 HIT_WAGON_NAMES=$(ls -d "$HIT_SCRIPT_DIR"/../../app/hitobito_* | sed 's|.*/hitobito_||')
 export HIT_SCRIPT_DIR
-export HIT_PROJECT
 export HIT_WAGON_NAMES
 source "$HIT_SCRIPT_DIR/welcome_info"
 
-PS1="HIT-$HIT_PROJECT> "
+PS1="HIT> "
 
 hit_welcome_info
 
@@ -21,7 +19,6 @@ hit_exec() {
 hit_error() {
   echo 'Command not found! Usage:'
   hit_help
-  echo "Current HIT Project: $HIT_PROJECT"
   return 1
 }
 

--- a/bin/hit/docker/attach
+++ b/bin/hit/docker/attach
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker attach "$HIT_PROJECT-$1-1" --detach-keys 'ctrl-c'
+docker attach hitobito-"$1"-1 --detach-keys ctrl-c

--- a/bin/hit/welcome_info
+++ b/bin/hit/welcome_info
@@ -14,7 +14,6 @@ EOF
 
 hit_welcome_info() {
   hit_welcome_banner
-  echo "Active HIT-Env: $HIT_PROJECT"
   echo -n "Present wagons: "
   echo $HIT_WAGON_NAMES
   echo

--- a/bin/reset_database
+++ b/bin/reset_database
@@ -2,13 +2,10 @@
 
 source $(dirname $0)/_basics
 
-project=$(basename $(pwd))
+docker compose down
 
-bin/stop
-
-volume=${project}_postgres
-echo "Removing docker volume $volume"
-docker volume rm $volume
+echo "Removing docker volume hitobito_postgres"
+docker volume rm hitobito_postgres
 
 echo "Making sure DB is seeded on next start"
 docker compose run -e SKIP_INIT=1 rails rm /seed/done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: hitobito
+
 services:
   rails: &rails
     build:


### PR DESCRIPTION
wenn man im docker-compose ein `name` angibt, muss man nicht immer das `HIT_PROJECT` basierend auf dem pwd setzten, sondern kann einfach den docker name angeben