### PR TITLE
feat: replace waitfortcp in entrypoint scripts with docker healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ bin/dev-env.sh
 To start the development environment, run:
 
 ```bash
+# This command might take a very long time on the first run, as the database needs to be seeded…
 hit up
 ```
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -83,6 +83,7 @@ touch docker/rails/Gemfile.lock
 To start the Hitobito application, run the following command in your shell:
 
 ```bash
+# This command might take a very long time on the first run, as the database needs to be seeded…
 docker compose up -d
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,19 @@ services:
     build:
       context: ./docker/rails
     image: ghcr.io/hitobito/development/rails
+    restart: unless-stopped
     user: "${RAILS_UID:-1000}"
     tty: true
     stdin_open: true
     depends_on:
-      - postgres
-      - mailcatcher
-      - cache
-      - webpack
+      postgres:
+        condition: service_healthy
+      mailcatcher:
+        condition: service_healthy
+      cache:
+        condition: service_started
+      webpack:
+        condition: service_started
     env_file: docker/rails/env
     environment:
       WEBPACKER_DEV_SERVER_HOST: webpack
@@ -26,6 +31,11 @@ services:
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
       - ./docker/rails/Gemfile.lock:/usr/src/app/hitobito/Gemfile.lock
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:3000/healthz"]
+      interval: 5s
+      timeout: 5s
+      start_period: 30m
 
   rails_test:
     <<: *rails
@@ -39,7 +49,8 @@ services:
       SKIP_SEEDS: 1
       SKIP_BUNDLE_INSTALL: 1
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
   worker:
     <<: *rails
@@ -50,26 +61,39 @@ services:
       SKIP_SEEDS: 1
       SKIP_BUNDLE_INSTALL: 1
     depends_on:
-      - rails
-      - postgres
-      - mailcatcher
-      - cache
+      rails:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      mailcatcher:
+        condition: service_healthy
+      cache:
+        condition: service_started
+    healthcheck:
+      disable: true
 
   # Dependencies
   mailcatcher:
     image: ghcr.io/hitobito/development/mailcatcher
+    restart: unless-stopped
     build:
       context: ./docker/mailcatcher
     ports:
       - "127.0.0.1:1025:1025"
       - "127.0.0.1:1080:1080"
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:1080"]
+      interval: 5s
+      timeout: 5s
 
   cache:
     image: memcached:1.6-alpine
     command: [ memcached, -l, '0.0.0.0', -p, '11211' ]
+    restart: unless-stopped
 
   postgres:
     image: postgres:16
+    restart: unless-stopped
     env_file: ./docker/postgres.env
     ports:
       - "127.0.0.1:5432:5432"
@@ -77,12 +101,18 @@ services:
       - ./docker/postgresql-setup.sql:/docker-entrypoint-initdb.d/postgresql-setup.sql:ro
       - ./docker/test-setup-postgresql.sql:/docker-entrypoint-initdb.d/test-setup-postgresql.sql:ro
       - postgres:/var/lib/postgresql/data
-      
+    healthcheck:
+      # Password is autodetected from env vars…
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+
   webpack:
     build:
       context: ./docker/rails
     image: ghcr.io/hitobito/development/rails
     entrypoint: [ "webpack-entrypoint.sh" ]
+    restart: unless-stopped
     env_file: docker/rails/env
     environment:
       WEBPACKER_DEV_SERVER_HOST: webpack
@@ -96,6 +126,9 @@ services:
       - hitobito_bundle:/opt/bundle
       - hitobito_yarn_cache:/home/developer/.cache/yarn
       - ./docker/rails/Gemfile.lock:/usr/src/app/hitobito/Gemfile.lock
+    depends_on:
+      postgres:
+        condition: service_healthy
 
 volumes:
   postgres:

--- a/docker/rails/Dockerfile
+++ b/docker/rails/Dockerfile
@@ -63,7 +63,6 @@ RUN bash -vxc 'gem install cmdparse pastel'
 
 COPY ./rails-entrypoint.sh /usr/local/bin
 COPY ./webpack-entrypoint.sh /usr/local/bin
-COPY ./waitfortcp /usr/local/bin
 
 RUN mkdir /opt/bundle && chmod 777 /opt/bundle
 RUN mkdir /seed && chmod 777 /seed

--- a/docker/rails/rails-entrypoint.sh
+++ b/docker/rails/rails-entrypoint.sh
@@ -39,10 +39,6 @@ initialize() {
         done
     fi
 
-    echo "⚙️  Testing DB connection"
-    timeout 300s waitfortcp "${RAILS_DB_HOST-db}" "${RAILS_DB_PORT-3306}"
-    echo "✅ DB server is ready"
-
     if [ -z "$SKIP_RAILS_MIGRATIONS" ]; then
         echo "⚙️  Performing migrations"
         bundle exec rails db:migrate wagon:migrate

--- a/docker/rails/waitfortcp
+++ b/docker/rails/waitfortcp
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-HOST=$1
-PORT=$2
-
-while ! (echo >"/dev/tcp/$HOST/$PORT") &>/dev/null; do
-  echo "💤 Waiting for $HOST:$PORT to become available."
-  sleep 1
-done

--- a/docker/rails/webpack-entrypoint.sh
+++ b/docker/rails/webpack-entrypoint.sh
@@ -17,10 +17,6 @@ done
 echo "Running yarn install"
 bundle exec rails webpacker:yarn_install
 
-echo "⚙️  Testing DB connection"
-timeout 300s waitfortcp "${RAILS_DB_HOST-db}" "${RAILS_DB_PORT-3306}"
-echo "✅ DB server is ready"
-
 echo "➡️ Handing control over to '$*''"
 
 echo "⚙️  Executing: $@"


### PR DESCRIPTION
This changes the responsibility of launching the containers in order from entrypoint scripts to docker compose which is already responsible for starting the containers anyway.

Helpful if the containers/setup are used not directly with docker compose (eg. devcontainers).