### PR TITLE
fix(compose): only mount specific override files into rails container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,11 @@ services:
       - ./app/:/usr/src/app
       - hitobito_bundle:/opt/bundle
       - seed:/seed
-      - ./docker/rails/home:/home/developer
       - /tmp/.X11-unix:/tmp/.X11-unix
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
+      - ./docker/rails/home/.bashrc:/home/developer/.bashrc
+      - ./docker/rails/home/.pryrc:/home/developer/.pryrc
       - ./docker/rails/Gemfile.lock:/usr/src/app/hitobito/Gemfile.lock
 
   rails_test:


### PR DESCRIPTION
This lead to a lot of confusing failures and random errors when restarting containers, especially also when using devcontainers.

In fact, i was not able to reproduce why it failed, but it made devcontainers not launch.